### PR TITLE
add workaround for cloudant/cors issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "blob-util": "^1.2.1",
-    "fetch-polyfill": "^0.8.2",
     "function-to-string": "^0.2.0",
     "node-assert": "0.0.1",
     "pouchdb-http": "^5.4.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "blob-util": "^1.2.1",
+    "fetch-polyfill": "^0.8.2",
     "function-to-string": "^0.2.0",
     "node-assert": "0.0.1",
     "pouchdb-http": "^5.4.5",
@@ -34,7 +35,7 @@
     "run-scripts": "^0.4.0",
     "standard": "^7.1.2",
     "watchify": "^3.7.0",
-    "zuul": "^3.10.1",
+    "zuul": "nolanlawson/zuul#post-results",
     "zuul-localtunnel": "nolanlawson/zuul-localtunnel#https"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,10 @@
-/* global it,describe,after,Worker,before,navigator,fetch,Headers */
+/* global it,describe,after,Worker,before,navigator,XMLHttpRequest */
 
 import PromiseWorker from 'promise-worker'
 import functionToString from 'function-to-string'
 import tests from './tests'
 import Promise from 'pouchdb-promise'
 import UAParser from 'ua-parser-js'
-import _fetch from 'fetch-polyfill'
-
-console.log(_fetch)
 
 function setupServiceWorker () {
   return navigator.serviceWorker.register('service-worker-bundle.js', {
@@ -93,13 +90,19 @@ describe('html5workertest', function () {
       group: process.env.TRAVIS_BUILD_NUMBER || 0,
       version: 1
     }
+
     // non-standard; I forked zuul to add this behavior
-    return fetch('/__zuul/results', {
-      method: 'POST',
-      body: JSON.stringify(jsonToPost),
-      headers: new Headers({
-        'Content-Type': 'application/json'
-      })
+    return new Promise((resolve, reject) => {
+      var xhr = new XMLHttpRequest()
+      xhr.open('POST', '/__zuul/results')
+      xhr.setRequestHeader('Content-Type', 'application/json')
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 300) {
+          resolve()
+        }
+      }
+      xhr.onerror = reject
+      xhr.send(JSON.stringify(jsonToPost))
     })
   }
 


### PR DESCRIPTION
For some reason Edge isn't able to post to Cloudant using CORS because it gets a 401. I couldn't reproduce locally; seems to be a SauceLabs network issue or something like that. No motivation to debug it, so I just hacked an extra API on top of Zuul to proxy a POST on to Cloudant: https://github.com/nolanlawson/zuul/tree/post-results

This is an awful hack and I should feel ashamed.
