### PR TITLE
feat: add WebTransport API

### DIFF
--- a/src/apiTests.js
+++ b/src/apiTests.js
@@ -327,6 +327,12 @@ var tests = [
     category: 'Miscellaneous',
     func: () => typeof OffscreenCanvas !== 'undefined',
     specification: 'https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface'
+  },
+  {
+    name: 'WebTransport',
+    category: 'Network',
+    func: () => typeof WebTransport !== 'undefined',
+    specification: 'https://www.w3.org/TR/webtransport/'
   }
 ]
 


### PR DESCRIPTION
In development in multiple browsers. Will be using https://github.com/libp2p/js-libp2p-webtransport for an upcoming demo, and thought it should probably be in your list of tests.